### PR TITLE
Fix: handle extra double quotes when empty value

### DIFF
--- a/helpers/csv.js
+++ b/helpers/csv.js
@@ -73,7 +73,11 @@ function fromCsvStringToArray(string, tableName) {
   }
 
   if (!reValid.test(string)) {
-    if (string.match(/""""/)) {
+
+    if (string.match(/,"(("")+)",/g) ) { // remove all extra double-quote if value should be an empty string
+      string = string.replace(/,"(("")+)",/g, ',"",');
+      return fromCsvStringToArray(string, tableName);
+    } else if (string.match(/""""/) ) {
       string = string.replace(/""""/g, '\\"\\"');
       return fromCsvStringToArray(string, tableName);
     } else if (string.match(/,"""/)) { // Handle the case with 3 " at start/end of string
@@ -86,6 +90,7 @@ function fromCsvStringToArray(string, tableName) {
       string = string.replace(/""/g, '\\"');
       return fromCsvStringToArray(string, tableName);
     }
+    
     process.notices.addWarning(__filename, `Row not valid in table ${tableName}: ${string}`);
     return [];
   }

--- a/helpers/csv.js
+++ b/helpers/csv.js
@@ -74,8 +74,8 @@ function fromCsvStringToArray(string, tableName) {
 
   if (!reValid.test(string)) {
 
-    if (string.match(/,"(("")+)",/g) ) { // remove all extra double-quote if value should be an empty string
-      string = string.replace(/,"(("")+)",/g, ',"",');
+    if (string.match(/,"(("")+)",/) ) { // remove all extra double-quote if value should be -> ""
+      string = string.replace(/,"(("")+)",/g, ',"\\"\\"",');
       return fromCsvStringToArray(string, tableName);
     } else if (string.match(/""""/) ) {
       string = string.replace(/""""/g, '\\"\\"');


### PR DESCRIPTION
## Issue
CSV wasn't handling this edge case correctly

http://transitupdateui.transitapp.com/notices/e28c03ed858a4128dd37ed1d6c1b5636

## What has been done
- added a new case to the switch-like statement

## Example 
- will transform:
1,"MB9","Broad St / Lincoln St",`""""""`,42.343861898414,-71.5629380382858,0
- to :
1,"MB9","Broad St / Lincoln St",`""`,42.343861898414,-71.5629380382858,0

- instead of :
1,"MB9","Broad St / Lincoln St",`\"\\\"`,42.343861898414,-71.5629380382858,0