### PR TITLE
Fix/use stream when importing gtfs

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "acomb": "1.2.2",
     "async": "2.6.0",
+    "deasync": "^0.1.15",
     "debug": "3.1.0",
     "fs-extra": "5.0.0",
     "papaparse": "^4.6.3"


### PR DESCRIPTION
## Issue:
Large files were not parsable using `fs.readFileSync`. 

## Fix:

Instead of reading the entire file into memory, I use a stream. But so as to not change the external API and have to change thousands of lines of code in UpdateStaticData, I use an npm package [deasync](https://www.npmjs.com/package/deasync).

## Other things

After updating the import file, I noticed we're opening the file in memory in the export script. So I decided to go ahead and use streams there too.