### PR TITLE
Fix/import export with large files

### DIFF
--- a/helpers/export.js
+++ b/helpers/export.js
@@ -103,6 +103,18 @@ function exportTable(tableName, gtfs, outputPath, callback) {
 
     let rows = [];
 
+    /*
+      About why the async wrapper is used inside the async.eachSeries:
+      If the function async.eachSeries runs without doing anything, just calling the callback (which
+      happens when there are a lot of empty objects), it crashes. It is a known bug of async.
+      They don't fix it due to performance reasons (see Common Pitfalls - https://caolan.github.io/async/v3/)
+      To deal with this, we simply wrap the possible asynchronous function with the keyword async.
+      The ES2017 async functions are returned as-is.
+      This is useful for preventing stack overflows (RangeError: Maximum call stack size exceeded),
+      and generally keeping Zalgo contained. Hence, Async Functions are immune to Zalgo's corrupting influences,
+      as they always resolve on a later tick.
+      More info on Zalgo (https://blog.izs.me/2013/08/designing-apis-for-asynchrony)
+    */
     async.eachSeries(gtfs.getIndexedTable(tableName), async ([key, object]) => {
       if (deepness === 0 || deepness === 1) {
         if (gtfs._preExportItemFunction) {

--- a/helpers/import.js
+++ b/helpers/import.js
@@ -106,7 +106,7 @@ function getKeysAndRowsSlices(buffer, regexPatternObjects, tableName) {
 function processGtfsTable(gtfs, keys, rowsSlices, tableName, indexKeys) {
   let table = (indexKeys.setOfItems) ? new Set() : new Map();
 
-  if (rowsSlices === undefined || rowsSlices === null || rowsSlices.length === 0) {
+  if (!rowsSlices || rowsSlices.length === 0) {
     return table;
   }
 

--- a/helpers/import.js
+++ b/helpers/import.js
@@ -138,9 +138,8 @@ Row: ${parsedRow.data[error.row].join(',')}`;
       });
     }
 
-    const [, ...rows] = parsedRow.data; // we don't need the header row, it's already stored in parsedKeys/trimmedKeys
-
-    rows.forEach((row) => {
+    for (let i = 1; i < parsedRow.data.length; i += 1) { // we only want to add to the table the remaining rows
+      const row = parsedRow.data[i];
       const trimmedRow = row.map(value => value.trim());
       if (trimmedRow !== null) {
         const item = new GtfsRow(trimmedRow);
@@ -159,7 +158,7 @@ Row: ${parsedRow.data[error.row].join(',')}`;
           table.add(item);
         }
       }
-    });
+    }
   });
 
   if (errorMessage && gtfs._shouldThrow) {

--- a/helpers/import.js
+++ b/helpers/import.js
@@ -5,6 +5,9 @@
 const infoLog = require('debug')('gtfsNodeLib:i');
 const fs = require('fs-extra');
 const Papa = require('papaparse');
+const { StringDecoder } = require('string_decoder');
+
+const eachWithLog = require('./logging_iterator_wrapper');
 
 /**
  * Import a table in the GTFS.
@@ -17,8 +20,13 @@ function importTable(gtfs, tableName) {
   const fullPath = `${gtfs.getPath() + tableName}.txt`;
 
   if (fs.existsSync(fullPath)) {
-    const fileContent = fs.readFileSync(fullPath, 'utf8');
-    gtfs._tables.set(tableName, processGtfsTable(gtfs, fileContent, tableName, indexKeys));
+    const fileContent = fs.readFileSync(fullPath);
+    const { keys, rowsSlices } = getKeysAndRowsSlices(
+      fileContent,
+      gtfs._regexPatternObjectsByTableName.get(tableName),
+      tableName
+    );
+    gtfs._tables.set(tableName, processGtfsTable(gtfs, keys, rowsSlices, tableName, indexKeys));
   } else {
     infoLog(`Empty table will be set for table ${tableName} (no input file at path ${gtfs._path}).`);
 
@@ -38,87 +46,127 @@ function importTable(gtfs, tableName) {
  * Private functions
  */
 
-function processGtfsTable(gtfs, fileContent, tableName, indexKeys) {
-  const parsedFileContent = Papa.parse(fileContent, {
-    delimiter: ',',
-    skipEmptyLines: true,
-  });
+function getKeysAndRowsSlices(buffer, regexPatternObjects, tableName) {
+  let keys;
+  const rowsSlices = [];
+  let rowsSlice;
+  let position = 0;
+  const batchLength = 5000000; // 5mb
+  let merge;
+  /*
+   Use string decoder to properly decode utf8 characters. Characters not in the basic ASCII take more
+   than one byte.
+   If the end of the batch cuts one of those characters, then we will yield weird characters.
+   decoder will accumulate any "lost" utf8 character at the end of the batch and accumulate it for the next
+   iteration.
+    */
+  const decoder = new StringDecoder('utf8');
+  const rowsSliceRegex = /(.*[\r\n]+)((.*[\r\n]*)*)/;
 
-  if (parsedFileContent.errors.length) {
-    let errorMessage = `Invalid rows in table ${tableName}:\n`;
+  while (position < buffer.length) {
+    rowsSlice = decoder.write(buffer.slice(position, Math.min(buffer.length, position + batchLength)));
 
-    parsedFileContent.errors.forEach((error) => {
-      errorMessage += `Line: ${error.row}
-Issue: ${error.message}
-Row: ${parsedFileContent.data[error.row].join(',')}`;
-    });
+    if (regexPatternObjects) {
+      regexPatternObjects.forEach(({ regex, pattern }) => {
+        const modifiedRowsSlice = rowsSlice.replace(regex, pattern || '');
 
-    if (gtfs._shouldThrow === true) {
-      throw new Error(errorMessage);
+        if (modifiedRowsSlice !== rowsSlice) {
+          process.notices.addInfo(__filename, `Applying regex replace to table: "${tableName}". regex: "${regex}".`);
+          rowsSlice = modifiedRowsSlice;
+        }
+      });
     }
+
+    const rowsSliceIndex = position / batchLength;
+
+    if (!keys) {
+      const [, firstRowSlice, remainingRowsSlice] = rowsSlice.match(rowsSliceRegex);
+      keys = firstRowSlice;
+      rowsSlice = remainingRowsSlice;
+    }
+
+    if (merge) {
+      const [, firstRowSlice, remainingRowsSlice] = rowsSlice.match(rowsSliceRegex);
+      rowsSlices[rowsSliceIndex - 1] += firstRowSlice;
+      rowsSlice = remainingRowsSlice;
+    }
+
+    rowsSlices[rowsSliceIndex] = rowsSlice;
+
+    merge = rowsSlices[rowsSlice.length] !== '\n';
+    position += batchLength;
   }
 
-  const [keys, ...rows] = parsedFileContent.data;
+  return {
+    keys,
+    rowsSlices,
+  };
+}
 
-  const trimmedKeys = keys.map(key => key.trim());
+function processGtfsTable(gtfs, keys, rowsSlices, tableName, indexKeys) {
+  let table = (indexKeys.setOfItems) ? new Set() : new Map();
+
+  if (rowsSlices === undefined || rowsSlices === null || rowsSlices.length === 0) {
+    return table;
+  }
+
+  const parsedKeys = Papa.parse(keys, { delimiter: ',', skipEmptyLines: true });
+  const trimmedKeys = parsedKeys.data[0].map(key => key.trim());
   checkThatKeysIncludeIndexKeys(trimmedKeys, indexKeys, tableName);
 
   const GtfsRow = createGtfsClassForKeys(trimmedKeys);
+  let errorMessage;
 
-  return processGtfsTableRows(gtfs, tableName, trimmedKeys, rows, indexKeys, GtfsRow);
-}
-
-function processGtfsTableRows(gtfs, tableName, keys, rows, indexKeys, GtfsRow) {
-  let table = (indexKeys.setOfItems) ? new Set() : new Map();
-
-  const regexPatternObjects = gtfs._regexPatternObjectsByTableName.get(tableName);
-
-  rows.forEach((row) => {
-    if (regexPatternObjects) {
-      row = applyRegexPatternObjectsByTableName(regexPatternObjects, keys, row, tableName);
+  eachWithLog(`Importation:${tableName}`, rowsSlices, (rowsSlice) => {
+    if (!rowsSlice || !rowsSlice.trim) {
+      return;
     }
 
-    const trimmedRow = row.map(value => value.trim());
-    const gtfsRow = new GtfsRow(trimmedRow);
+    rowsSlice = rowsSlice.trim();
 
-    if (indexKeys.indexKey) {
-      table.set(gtfsRow[indexKeys.indexKey], gtfsRow);
-    } else if (indexKeys.firstIndexKey && indexKeys.secondIndexKey) {
-      if (table.has(gtfsRow[indexKeys.firstIndexKey]) === false) {
-        table.set(gtfsRow[indexKeys.firstIndexKey], new Map());
+    const parsedRow = Papa.parse(`${keys}${rowsSlice}`, { delimiter: ',', skipEmptyLines: true });
+
+    if (parsedRow.errors.length) {
+      if (!errorMessage) {
+        errorMessage = `Invalid rows in table ${tableName}:\n`;
       }
 
-      table.get(gtfsRow[indexKeys.firstIndexKey]).set(gtfsRow[indexKeys.secondIndexKey], gtfsRow);
-    } else if (indexKeys.singleton) {
-      table = gtfsRow;
-    } else if (indexKeys.setOfItems) {
-      table.add(gtfsRow);
+      parsedRow.errors.forEach((error) => {
+        errorMessage += `Line: ${error.row}
+Issue: ${error.message}
+Row: ${parsedRow.data[error.row].join(',')}`;
+      });
     }
+
+    const [, ...rows] = parsedRow.data; // we don't need the header row, it's already stored in parsedKeys/trimmedKeys
+
+    rows.forEach((row) => {
+      const trimmedRow = row.map(value => value.trim());
+      if (trimmedRow !== null) {
+        const item = new GtfsRow(trimmedRow);
+
+        if (indexKeys.indexKey) {
+          table.set(item[indexKeys.indexKey], item);
+        } else if (indexKeys.firstIndexKey && indexKeys.secondIndexKey) {
+          if (table.has(item[indexKeys.firstIndexKey]) === false) {
+            table.set(item[indexKeys.firstIndexKey], new Map());
+          }
+
+          table.get(item[indexKeys.firstIndexKey]).set(item[indexKeys.secondIndexKey], item);
+        } else if (indexKeys.singleton) {
+          table = item;
+        } else if (indexKeys.setOfItems) {
+          table.add(item);
+        }
+      }
+    });
   });
+
+  if (errorMessage && gtfs._shouldThrow) {
+    throw new Error(errorMessage);
+  }
 
   return table;
-}
-
-function applyRegexPatternObjectsByTableName(regexPatternObjects, keys, row, tableName) {
-  const rowStringified = String(row);
-  let modifiedRowStringified = rowStringified;
-
-  regexPatternObjects.forEach(({ regex, pattern }) => {
-    modifiedRowStringified = rowStringified.replace(regex, pattern || '');
-
-    if (modifiedRowStringified !== rowStringified) {
-      process.notices.addInfo(
-        'Applying Changes on Raw GTFS',
-        `Applying regex replace to table: "${tableName}". regex: "${regex}".`
-      );
-    }
-  });
-
-  const parsedModifiedRow = Papa.parse(`${keys}\n${modifiedRowStringified}`, {
-    delimiter: ',',
-  });
-
-  return parsedModifiedRow.data[1];
 }
 
 function checkThatKeysIncludeIndexKeys(sortedKeys, indexKeys, tableName) {

--- a/helpers/logging_iterator_wrapper.js
+++ b/helpers/logging_iterator_wrapper.js
@@ -21,7 +21,7 @@ module.exports = (prefix, valueByKey, iteratee) => {
 
     numberOfKeysDone += 1;
 
-    if (Date.now() - lastLogAt > interval && process.env.TEST === undefined) {
+    if (!process.env.TEST && Date.now() - lastLogAt > interval) {
       const numberOfTotalKeys = valueByKey instanceof Array ? valueByKey.length : valueByKey.size;
       const percentageDone = (numberOfKeysDone / numberOfTotalKeys) * 100;
 

--- a/helpers/logging_iterator_wrapper.js
+++ b/helpers/logging_iterator_wrapper.js
@@ -22,7 +22,13 @@ module.exports = (prefix, valueByKey, iteratee) => {
     numberOfKeysDone += 1;
 
     if (Date.now() - lastLogAt > interval && process.env.TEST === undefined) {
-      const percentageDone = (numberOfKeysDone / valueByKey.size) * 100;
+      let percentageDone;
+      if (valueByKey instanceof Array) {
+        percentageDone = (numberOfKeysDone / valueByKey.length) * 100;
+      } else {
+        percentageDone = (numberOfKeysDone / valueByKey.size) * 100;
+      }
+
       infoLog(`[${prefix}] ${percentageDone.toPrecision(2)}% done`);
 
       lastLogAt = Date.now();

--- a/helpers/logging_iterator_wrapper.js
+++ b/helpers/logging_iterator_wrapper.js
@@ -22,12 +22,8 @@ module.exports = (prefix, valueByKey, iteratee) => {
     numberOfKeysDone += 1;
 
     if (Date.now() - lastLogAt > interval && process.env.TEST === undefined) {
-      let percentageDone;
-      if (valueByKey instanceof Array) {
-        percentageDone = (numberOfKeysDone / valueByKey.length) * 100;
-      } else {
-        percentageDone = (numberOfKeysDone / valueByKey.size) * 100;
-      }
+      const numberOfTotalKeys = valueByKey instanceof Array ? valueByKey.length : valueByKey.size;
+      const percentageDone = (numberOfKeysDone / numberOfTotalKeys) * 100;
 
       infoLog(`[${prefix}] ${percentageDone.toPrecision(2)}% done`);
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "homepage": "https://github.com/TransitApp/gtfsNodeLib#readme",
   "dependencies": {
-    "acomb": "1.2.2",
     "async": "2.6.0",
     "debug": "3.1.0",
     "fs-extra": "5.0.0",

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -82,6 +82,28 @@ describe('Tests on GTFS', () => {
     });
   });
 
+  // it('Tests on importing/exporting very large file', (done) => {
+  // You'll need to download a large CSV and place it within the samples/veryLargeFile folder.
+  // A good one is STM stop_times.txt
+  //   const path = `${__dirname}/samples/veryLargeFile`;
+  //   const gtfs = new Gtfs(path);
+  //
+  //   const stopTime = gtfs.getStopTimeWithTripIdAndStopSequence('197160641', '1');
+  //   expect(stopTime.stop_id).to.equal('51095');
+  //
+  //   const outputPath = `${__dirname}/temp_4865ce67d01f96a489fbd0e71adef800b/`;
+  //
+  //   gtfs.exportAtPath(outputPath, (exportError) => {
+  //     if (exportError) { throw exportError; }
+  //
+  //     fs.remove(outputPath, (removeError) => {
+  //       if (removeError) { throw removeError; }
+  //
+  //       done();
+  //     });
+  //   });
+  // });
+
   it('Tests on the regex/pattern applied to fix a bad CSV', (done) => {
     const path = `${__dirname}/samples/2/`;
     const gtfsWithoutFix = new Gtfs(path);


### PR DESCRIPTION
## Issue:
Large files aren't able to be stored in memory.

## Fix:
[Issue](https://github.com/TransitApp/UpdateStaticData/issues/10283)

Import: I chunkate the files into 5mb strings so as to parse by chunk instead of the whole file.

Export: I append by row instead of writing the entire file at once.

## Notes:
Both of these ways of importing/exporting were used in previous versions of gtfsNodeLib before version 3.5.1 except they used our internal csv parser. So, I reverted back to these old ways except I slightly modified them to use PapaParse. 

## To think about:
- Variation on chunk size