### PR TITLE
Fix: table keys with quotes should be removed

### DIFF
--- a/helpers/import.js
+++ b/helpers/import.js
@@ -111,7 +111,7 @@ function processGtfsTable(gtfs, keys, rowsSlices, tableName, indexKeys) {
   }
 
   const parsedKeys = Papa.parse(keys, { delimiter: ',', skipEmptyLines: true });
-  const trimmedKeys = parsedKeys.data[0].map(key => key.trim());
+  const trimmedKeys = parsedKeys.data[0].map(key => key.trim().replace(/"/g, ''));
   checkThatKeysIncludeIndexKeys(trimmedKeys, indexKeys, tableName);
 
   const GtfsRow = createGtfsClassForKeys(trimmedKeys);


### PR DESCRIPTION
Fix error:
```
Error: Keys of table stops do not contain the index key: stop_id.
 The values are: "stop_id",stop_code,stop_name,stop_desc,stop_lat,stop_lon,zone_id,stop_url,location_type,parent_station,stop_timezone
```

Feeds with issue: OCTA