### PR TITLE
Fix/Deletion of non-existent entity fails silently

### DIFF
--- a/gtfs.js
+++ b/gtfs.js
@@ -151,7 +151,12 @@ function removeItems(gtfs, tableName, items) {
   }
 
   if (indexKeys.indexKey) {
-    items.forEach(item => indexedTable.delete(item[indexKeys.indexKey]));
+    items.forEach(item => {
+      if (!indexedTable.has(item[indexKeys.indexKey])) {
+        throw new Error(`item does not exist in table: ${tableName}`);
+      }
+      indexedTable.delete(item[indexKeys.indexKey])
+    });
     return;
   }
 

--- a/tests/test_agencies.js
+++ b/tests/test_agencies.js
@@ -22,11 +22,15 @@ describe('Tests on GTFS agencies', () => {
     ]);
     expect(sortedKeys(gtfs.getIndexedAgencies())).to.deep.equal(['agency_0', 'agency_1', 'agency_2', 'agency_3']);
 
-    gtfs.removeAgency(gtfs.getAgencyWithId('agency_2'));
+    const agency2 = gtfs.getAgencyWithId('agency_2');
+    gtfs.removeAgency(agency2);
     expect(sortedKeys(gtfs.getIndexedAgencies())).to.deep.equal(['agency_0', 'agency_1', 'agency_3']);
-
-    gtfs.removeAgencies([gtfs.getAgencyWithId('agency_0'), gtfs.getAgencyWithId('agency_3')]);
+    expect(() => gtfs.removeAgency(agency2)).to.throw("item does not exist in table: agency");
+    
+    const agency3 = gtfs.getAgencyWithId('agency_3');
+    gtfs.removeAgencies([agency0, agency3]);
     expect(sortedKeys(gtfs.getIndexedAgencies())).to.deep.equal(['agency_1']);
+    expect(() => gtfs.removeAgencies([agency0, agency3])).to.throw("item does not exist in table: agency");
 
     gtfs.setIndexedAgencies(new Map([['agency_0', agency0]]));
     expect(sortedKeys(gtfs.getIndexedAgencies())).to.deep.equal(['agency_0']);

--- a/tests/test_calendars.js
+++ b/tests/test_calendars.js
@@ -22,12 +22,16 @@ describe('Tests on GTFS calendars', () => {
     ]);
     expect(sortedKeys(gtfs.getIndexedCalendars())).to.deep.equal(['service_0', 'service_1', 'service_2', 'service_3']);
 
-    gtfs.removeCalendar(gtfs.getCalendarWithServiceId('service_2'));
+    const calendar2 = gtfs.getCalendarWithServiceId('service_2');
+    gtfs.removeCalendar(calendar2);
     expect(sortedKeys(gtfs.getIndexedCalendars())).to.deep.equal(['service_0', 'service_1', 'service_3']);
-
-    gtfs.removeCalendars([gtfs.getCalendarWithServiceId('service_0'), gtfs.getCalendarWithServiceId('service_3')]);
+    expect(() => gtfs.removeCalendar(calendar2)).to.throw("item does not exist in table: calendar");
+    
+    const calendar3 = gtfs.getCalendarWithServiceId('service_3');
+    gtfs.removeCalendars([calendar0, calendar3]);
     expect(sortedKeys(gtfs.getIndexedCalendars())).to.deep.equal(['service_1']);
-
+    expect(() => gtfs.removeCalendars([calendar0, calendar3])).to.throw("item does not exist in table: calendar");
+    
     gtfs.setIndexedCalendars(new Map([['service_0', calendar0]]));
     expect(sortedKeys(gtfs.getIndexedCalendars())).to.deep.equal(['service_0']);
 

--- a/tests/test_fare_attributes.js
+++ b/tests/test_fare_attributes.js
@@ -36,6 +36,7 @@ describe('Tests on GTFS fare attributes', () => {
     expect(gtfs.getFareAttributeWithId('fareAttribute.fare_id.1') !== undefined).to.equal(true);
     expect(gtfs.getFareAttributeWithId('fareAttribute.fare_id.2') !== undefined).to.equal(false);
     expect(gtfs.getFareAttributeWithId('fareAttribute.fare_id.3') !== undefined).to.equal(true);
+    expect(() => gtfs.removeFareAttribute(fareAttribute2)).to.throw("item does not exist in table: fare_attributes");
 
     gtfs.removeFareAttributes([fareAttribute1, fareAttribute3]);
 
@@ -43,6 +44,7 @@ describe('Tests on GTFS fare attributes', () => {
     expect(gtfs.getFareAttributeWithId('fareAttribute.fare_id.1') !== undefined).to.equal(false);
     expect(gtfs.getFareAttributeWithId('fareAttribute.fare_id.2') !== undefined).to.equal(false);
     expect(gtfs.getFareAttributeWithId('fareAttribute.fare_id.3') !== undefined).to.equal(false);
+    expect(() => gtfs.removeFareAttributes([fareAttribute1, fareAttribute3])).to.throw("item does not exist in table: fare_attributes");
 
     done();
   });

--- a/tests/test_generic_table_functions.js
+++ b/tests/test_generic_table_functions.js
@@ -40,12 +40,16 @@ describe('Tests on GTFS generic table functions', () => {
     expect(sortedKeys(gtfs.getIndexedRoutes())).to.deep.equal(['route_0', 'route_1', 'route_2',
       'route_3', 'route_utf8', 'route_x', 'route_y']);
 
-    gtfs.removeItemInTable(gtfs.getRouteWithId('route_2'), ROUTE_TABLE_NAME);
+    const route2 = gtfs.getRouteWithId('route_2')
+    gtfs.removeItemInTable(route2, ROUTE_TABLE_NAME);
     expect(sortedKeys(gtfs.getIndexedRoutes())).to.deep.equal(['route_0', 'route_1', 'route_3',
       'route_utf8', 'route_x', 'route_y']);
+    expect(() => gtfs.removeItemInTable(route2, ROUTE_TABLE_NAME)).to.throw("item does not exist in table: routes");
 
-    gtfs.removeItemsInTable([gtfs.getRouteWithId('route_0'), gtfs.getRouteWithId('route_3')], ROUTE_TABLE_NAME);
+    const route3 = gtfs.getRouteWithId('route_3');
+    gtfs.removeItemsInTable([route0, route3], ROUTE_TABLE_NAME);
     expect(sortedKeys(gtfs.getIndexedRoutes())).to.deep.equal(['route_1', 'route_utf8', 'route_x', 'route_y']);
+    expect(() => gtfs.removeItemsInTable([route0, route3], ROUTE_TABLE_NAME)).to.throw("item does not exist in table: routes");
 
     gtfs.setIndexedItemsAsTable(new Map([['route_0', route0]]), ROUTE_TABLE_NAME);
     expect(sortedKeys(gtfs.getIndexedRoutes())).to.deep.equal(['route_0']);

--- a/tests/test_pathways.js
+++ b/tests/test_pathways.js
@@ -62,15 +62,15 @@ describe('Tests on GTFS pathways', () => {
     ]);
     expect(sortedKeys(gtfs.getIndexedPathways())).to.deep.equal(['1', '2', '3', '4', '5']);
 
-    gtfs.removePathway(gtfs.getPathwayWithPathwayId('1'));
+    gtfs.removePathway(pathway1);
     expect(sortedKeys(gtfs.getIndexedPathways())).to.deep.equal(['2', '3', '4', '5']);
+    expect(() => gtfs.removePathway(pathway1)).to.throw("item does not exist in table: pathways")
 
-    gtfs.removePathways([
-      gtfs.getPathwayWithPathwayId('2'),
-      gtfs.getPathwayWithPathwayId('3'),
-    ]);
+    const pathway3 = gtfs.getPathwayWithPathwayId('3');
+    gtfs.removePathways([pathway2, pathway3]);
 
     expect(sortedKeys(gtfs.getIndexedPathways())).to.deep.equal(['4', '5']);
+    expect(() => gtfs.removePathways([pathway2, pathway3])).to.throw("item does not exist in table: pathways")
 
     gtfs.setIndexedPathways(new Map([['1', pathway1], ['2', pathway2]]));
 

--- a/tests/test_routes.js
+++ b/tests/test_routes.js
@@ -26,12 +26,16 @@ describe('Tests on GTFS routes', () => {
     expect(sortedKeys(gtfs.getIndexedRoutes())).to.deep.equal(['route_0', 'route_1', 'route_2',
       'route_3', 'route_utf8', 'route_x', 'route_y']);
 
-    gtfs.removeRoute(gtfs.getRouteWithId('route_2'));
+    const route2 = gtfs.getRouteWithId('route_2');
+    gtfs.removeRoute(route2);
     expect(sortedKeys(gtfs.getIndexedRoutes())).to.deep.equal(['route_0', 'route_1', 'route_3',
       'route_utf8', 'route_x', 'route_y']);
+    expect(() => gtfs.removeRoute(route2)).to.throw("item does not exist in table: route");
 
-    gtfs.removeRoutes([gtfs.getRouteWithId('route_0'), gtfs.getRouteWithId('route_3')]);
+    const route3 = gtfs.getRouteWithId('route_3');
+    gtfs.removeRoutes([route0, route3]);
     expect(sortedKeys(gtfs.getIndexedRoutes())).to.deep.equal(['route_1', 'route_utf8', 'route_x', 'route_y']);
+    expect(() => gtfs.removeRoutes([route0, route3])).to.throw("item does not exist in table: route");
 
     gtfs.setIndexedRoutes(new Map([['route_0', route0]]));
     expect(sortedKeys(gtfs.getIndexedRoutes())).to.deep.equal(['route_0']);

--- a/tests/test_stops.js
+++ b/tests/test_stops.js
@@ -24,11 +24,15 @@ describe('Tests on GTFS stops', () => {
     ]);
     expect(sortedKeys(gtfs.getIndexedStops())).to.deep.equal(['stop_0', 'stop_1', 'stop_2', 'stop_3', 'stop_4']);
 
-    gtfs.removeStop(gtfs.getStopWithId('stop_2'));
+    const stop2 = gtfs.getStopWithId('stop_2');
+    gtfs.removeStop(stop2);
     expect(sortedKeys(gtfs.getIndexedStops())).to.deep.equal(['stop_0', 'stop_1', 'stop_3', 'stop_4']);
-
-    gtfs.removeStops([gtfs.getStopWithId('stop_1'), gtfs.getStopWithId('stop_3')]);
+    expect(() => gtfs.removeStop(stop2)).to.throw("item does not exist in table: stop");
+    
+    const stop3 = gtfs.getStopWithId('stop_3'); 
+    gtfs.removeStops([stop1, stop3]);
     expect(sortedKeys(gtfs.getIndexedStops())).to.deep.equal(['stop_0', 'stop_4']);
+    expect(() => gtfs.removeStops([stop1, stop3])).to.throw("item does not exist in table: stop");
 
     gtfs.setIndexedStops(new Map([['stop_0', stop0], ['stop_1', stop1]]));
     expect(sortedKeys(gtfs.getIndexedStops())).to.deep.equal(['stop_0', 'stop_1']);

--- a/tests/test_trips.js
+++ b/tests/test_trips.js
@@ -22,11 +22,15 @@ describe('Tests on GTFS trips', () => {
     ]);
     expect(sortedKeys(gtfs.getIndexedTrips())).to.deep.equal(['trip_0', 'trip_1', 'trip_2', 'trip_3']);
 
-    gtfs.removeTrip(gtfs.getTripWithId('trip_2'));
+    const trip2 = gtfs.getTripWithId('trip_2');
+    gtfs.removeTrip(trip2);
     expect(sortedKeys(gtfs.getIndexedTrips())).to.deep.equal(['trip_0', 'trip_1', 'trip_3']);
+    expect(() => gtfs.removeTrip(trip2)).to.throw("item does not exist in table: trip");
 
-    gtfs.removeTrips([gtfs.getTripWithId('trip_0'), gtfs.getTripWithId('trip_3')]);
+    const trip3 = gtfs.getTripWithId('trip_3');
+    gtfs.removeTrips([trip0, trip3]);
     expect(sortedKeys(gtfs.getIndexedTrips())).to.deep.equal(['trip_1']);
+    expect(() => gtfs.removeTrips([trip0, trip3])).to.throw("item does not exist in table: trip");
 
     gtfs.setIndexedTrips(new Map([['trip_0', trip0]]));
     expect(sortedKeys(gtfs.getIndexedTrips())).to.deep.equal(['trip_0']);


### PR DESCRIPTION
### Issue:
The issue is described [here](https://github.com/TransitApp/gtfsNodeLib/issues/20), if we try to delete an entity that does not exist it does not generate errors

### Fix:

- [x] Added a throw error in the removeItems fonction
- [x] Added tests on the different entities

